### PR TITLE
Replaced ExponentiallyDecayingReservoir with SlidingTimeWindowArrayReservoir

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.functionmetrics</groupId>
     <artifactId>function-metrics</artifactId>
-    <version>1.0.6</version>
+    <version>2.0.0</version>
     <name>Function Metrics</name>
     <url>https://github.com/santanusinha/function-metrics</url>
     <description>Annotation based function level metrics</description>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-core</artifactId>
-            <version>3.2.2</version>
+            <version>4.2.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Default timer implementation of dropwizard metrics uses `ExponentiallyDecayingReservoir` for histograms. 
Shortcomings of this reservoir are mentioned in this blog post - https://engineering.salesforce.com/be-careful-with-reservoirs-708884018daf

This PR aims at changing this to `SlidingTimeWindowArrayReservoir` to resolve stale latency histogram data issue.