### PR TITLE
Modified regex for VALID_PARAM_VALUE_PATTERN

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.appform.functionmetrics</groupId>
     <artifactId>function-metrics</artifactId>
-    <version>1.0.14-RC3</version>
+    <version>1.0.14-RC4</version>
     <name>Function Metrics</name>
     <url>https://github.com/santanusinha/function-metrics</url>
     <description>Annotation based function level metrics</description>
@@ -41,6 +41,13 @@
         <developer>
             <id>godofwharf</id>
             <name>Guruprasad Sridharan</name>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+        <developer>
+            <id>rjseniwal</id>
+            <name>Rajat Seniwal</name>
             <roles>
                 <role>developer</role>
             </roles>

--- a/src/main/java/io/appform/functionmetrics/FunctionMetricConstants.java
+++ b/src/main/java/io/appform/functionmetrics/FunctionMetricConstants.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
 
 public class FunctionMetricConstants {
     public static final String METRIC_DELIMITER = ".";
-    public static final Pattern VALID_PARAM_VALUE_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");
+    public static final Pattern VALID_PARAM_VALUE_PATTERN = Pattern.compile("^[a-zA-Z_][a-zA-Z-_0-9]*$");
 
     private FunctionMetricConstants() {}
 }

--- a/src/test/java/io/appform/functionmetrics/FunctionTimerAspectTest.java
+++ b/src/test/java/io/appform/functionmetrics/FunctionTimerAspectTest.java
@@ -116,6 +116,23 @@ public class FunctionTimerAspectTest {
     }
 
     @Test
+    public void testMetricsCollectionParameterValidWithHyphen() throws Exception {
+        final MyClass myClass = new MyClass();
+        myClass.parameterValidFunction("a","John_Cartier-047");
+
+        final FunctionInvocation invocation
+                = new FunctionInvocation("MyClass", "parameterValidFunction", "a.johnCartier-047");
+        final Timer failureTimer
+                = FunctionMetricsManager.timer(TimerDomain.FAILURE, invocation).orElse(null);
+        Assert.assertNotNull(failureTimer);
+        Assert.assertEquals(0, failureTimer.getCount());
+        final Timer successTimer
+                = FunctionMetricsManager.timer(TimerDomain.SUCCESS, invocation).orElse(null);
+        Assert.assertNotNull(successTimer);
+        Assert.assertEquals(1, successTimer.getCount());
+    }
+
+    @Test
     public void testMetricsCollectionParameterValidOverloadedFunction1() throws Exception {
         final MyClass myClass = new MyClass();
         myClass.parameterValidFunction(5,"John_Cartier047");


### PR DESCRIPTION
added hyphen as a valid character in the VALID_PARAM_VALUE_PATTERN regex pattern used for matching the param annotated with @MetricTerm